### PR TITLE
Fix: cyclic backbone detection for THIAZOLE_CYCLE (and similar) bonds

### DIFF
--- a/src/generic/graphs.py
+++ b/src/generic/graphs.py
@@ -38,17 +38,47 @@ def hamiltonian_path(G: nx.DiGraph,
         return None
 
 
-def parse_as_simple_cycle(G: nx.DiGraph) -> Union[List[int], None]:
-    try:
-        cycle_edges = nx.find_cycle(G)
-        cycle_uv = [(e[0], e[1]) for e in cycle_edges]  # tolerate possible 3-tuples from NetworkX
-        cycle_set = set(cycle_uv)
+def hamiltonian_cycle(G: nx.DiGraph,
+                      source: int) -> Optional[List[int]]:
+    ''' finds a hamiltonian cycle in G through source in an exhaustive manner '''
+    visited = set()
 
-        # Allow extra edges only if they're the reverse of an edge on the cycle (bidirectional edges).
-        if all(((u, v) in cycle_set) or ((v, u) in cycle_set)
-               for u, v in G.edges()):
-            return [u for u, v in cycle_uv]
-    except nx.NetworkXNoCycle:
+    def dfs(u: int) -> Optional[List[int]]:
+        visited.add(u)
+        if len(visited) == len(G.nodes()):
+            if G.has_edge(u, source):
+                return [u]
+        else:
+            for v in G.successors(u):
+                if v not in visited and (path := dfs(v)):
+                    return path + [u]
+
+        visited.remove(u)
+        return None
+
+    if path := dfs(source):
+        return path[::-1]
+    else:
+        return None
+
+
+def parse_as_simple_cycle(G: nx.DiGraph) -> Union[List[int], None]:
+    ''' parses G as a cycle spanning all of its nodes '''
+    if len(G) < 2:
+        return None
+
+    # a hamiltonian cycle visits every node, so any of them will do as a starting point
+    cycle = hamiltonian_cycle(G, min(G.nodes()))
+    if cycle is None:
+        return None
+
+    cycle_edges = set(pairwise(cycle)) | {(cycle[-1], cycle[0])}
+    # non-peptide backbone bonds are stored as two opposite edges,
+    # so an edge off the cycle is fine as long as it reverses one on the cycle
+    if all(((u, v) in cycle_edges) or ((v, u) in cycle_edges)
+           for u, v in G.edges()):
+        return cycle
+    else:
         return None
 
 


### PR DESCRIPTION
## Summary

This PR fixes a non-deterministic failure mode in cyclic NRP backbone parsing when the rBAN graph contains a non-`AMINO` backbone bond such as `THIAZOLE_CYCLE`.

The motivating case is **BGC0001393 (lugdunin)** from MIBiG. Across otherwise identical Nerpa runs, the self-match quality flipped between a strong correct alignment and a weak / wrong one — without any intentional change to the matching algorithm. The root cause was that the **cyclic** structure was sometimes parsed as **linear**, and the linearization then depended on rBAN’s arbitrary monomer numbering.

### Motivating rBAN graph (BGC0001393.0)

One observed numbering (the chemical graph is the same up to node IDs):

```yaml
compound_id: BGC0001393.0
nodes: {1: Val, 2: Cys, 3: Leu, 4: Trp, 5: Val, 6: Val, 7: Val}
edges:
  - [3, 7, AMINO]
  - [7, 6, AMINO]
  - [6, 5, AMINO]
  - [5, 2, THIAZOLE_CYCLE]
  - [2, 1, AMINO]
  - [1, 4, AMINO]
  - [4, 3, AMINO]
```

Across runs, rBAN can emit the same heptapeptide cycle with a different vertex numbering. That should not change the biological interpretation, but with the old cycle parser it did.

## Problem

When building the directed monomer graph, Nerpa stores every non-`AMINO` backbone bond as **two opposite directed edges** (`A→B` and `B→A`), so that orientation of bonds such as `THIAZOLE_CYCLE` / `OXAZOLE_CYCLE` / etc. does not matter.

The old `parse_as_simple_cycle` used `networkx.find_cycle` to pick **some** cycle, then checked that every other edge is either on that cycle or the reverse of a cycle edge.

On graphs with a bidirectional bond, `find_cycle` often returns the trivial **2-cycle** `A↔B` instead of the full monomer ring. The “simple cycle” check then fails, and `putative_backbones` falls back to a Hamiltonian **path** with `is_cyclic=False`.

Consequences:

1. The molecule is treated as linear even though it is cyclic.
2. Linearizations do **not** include all cyclic rotations.
3. The path start depends on rBAN node IDs → **non-deterministic** match scores for the same compound.

For BGC0001393 this showed up as:

| Situation | Best match for the BGC | RawScore (self) | LogOdds vs avg BGC |
|---|---|---|---|
| “Lucky” rBAN numbering | `BGC0001393.0` (correct) | −10.38 | **18.55** |
| “Unlucky” numbering / pre-fix | wrong NRP / broken self-align | ~−24 / missing from top-5000 | ~5 |

## Fix

In `src/generic/graphs.py`:

- Add `hamiltonian_cycle` (DFS, same style as the existing `hamiltonian_path`).
- Change `parse_as_simple_cycle` to require a **Hamiltonian** cycle (covers all nodes in the component), then keep the existing reverse-edge allowance for bidirectional non-`AMINO` bonds.

Starting node is `min(G.nodes())`. Because a Hamiltonian cycle visits every node, existence does not depend on the start, so rBAN numbering no longer flips cyclic ↔ linear for these cases.

## Results (MIBiG NRPS set, same inputs, stock monomer table)

Compared `nerpa2` **before** vs **after** this change:

| Metric | Before | After |
|---|---|---|
| BGCs evaluated | 302 | 303 |
| Good best-per-BGC matches | 173 | **178** |
| Precision (best-per-BGC) | 0.573 | **0.587** |
| Top-200 precision | 0.740 | **0.755** |

No regressions in the “was cyclic → no longer cyclic” sense on the dumped rBAN graphs (+12 components newly recognized as cyclic; 0 losses).

### Self-match recovered as best hit (5 BGCs, 0 losses)

| Genome | Best NRP before (LogOdds) | Best NRP after (LogOdds) |
|---|---|---|
| **BGC0001393** | `BGC0001128.0` / 5.32 (own NRP not in top-5000) | **`BGC0001393.0` / 18.55** |
| BGC0000320 | `BGC0000339.0` / 7.39 | `BGC0000320.0` / 11.61 |
| BGC0000333 | `BGC0001620.1` / 12.03 | `BGC0000333.0` / 12.56 |
| BGC0001042 | `BGC0000333.0` / 4.84 | `BGC0001042.0` / 4.47 |
| BGC0001469 | `BGC0000445.0` / 7.75 | `BGC0001469.0` / 14.84 |

After the fix, BGC0001393 again gets the correct full-residue alignment at RawScore −10.38 even when rBAN assigns a **third** different vertex numbering — i.e. the match is stable under node-id permutation.
